### PR TITLE
IM-15: Fix CI flow so that the tag points to the correct commit

### DIFF
--- a/.github/workflows/process.yml
+++ b/.github/workflows/process.yml
@@ -59,14 +59,6 @@ jobs:
         with:
           commit_message: 'podspec version upgrade v${{ needs.process.outputs.version }}'
           file_pattern: '*.podspec'
-      # Tag 
-      - name: Tag commit
-        if: ${{ contains(needs.process.outputs.version,'.') &&  steps.checkTag.outputs.exists != true }} 
-        uses: tvdias/github-tagger@v0.0.1
-        with:
-            repo-token: "${{ secrets.GITHUB_TOKEN }}"
-            tag: "v${{ needs.process.outputs.version }}"
-        
-
+          tagging_message: 'v${{ needs.process.outputs.version }}'
 
       


### PR DESCRIPTION
## Context
From the creation of this repository, the CI process has been wrong. The flow that creates the podspec version commit and then subsequently the tag has been adding the tag to the previous commit, instead of the last.

This has led to v0.3 pointing to the 0.2 podspec, v0.4 to the 0.3 podspec etc.

![image](https://user-images.githubusercontent.com/1099219/214090119-d784eba6-d568-41ec-b811-e2eb9dc0a1b8.png)

Both 0.5 and 0.7 have been fixed manually by recreating the tag by hand, which is why they point to the readme update commit instead.

## Issue
Manual test in a separate branch proved that `stefanzweifel/git-auto-commit-action@v4` and `tvdias/github-tagger@v0.0.1` don't play well together. It seems when github-tagger is ran, it cannot yet see the commit created by git-auto-commit

## Solution
I've tried adding a "git pull" or second iteration of the git-checkout action between the two steps, to no success.
What did work however was to remove `github-tagger` altogether and use the tagging capabilities of `git-auto-commit-action` instead
